### PR TITLE
Add the ability to force a specific health measurement

### DIFF
--- a/lib/litmus_paper/app.rb
+++ b/lib/litmus_paper/app.rb
@@ -65,6 +65,7 @@ module LitmusPaper
         body = "Health: #{health.value}\n"
         if health.forced?
           if health.direction == :health
+            status = "health"
             reason = health.forced_reason.split("\n").join(" ")
           else
             reason = health.forced_reason

--- a/lib/litmus_paper/cli/admin/force.rb
+++ b/lib/litmus_paper/cli/admin/force.rb
@@ -14,7 +14,7 @@ module LitmusPaper
               options[:delete] = true
             end
             opts.on("-r", "--reason=reason", String, "Reason for status file") do |reason|
-              options[:reason] = reason
+              options[:reason] = reason.gsub("\n", " ")
             end
           end
 
@@ -31,7 +31,7 @@ module LitmusPaper
           else
             if !options.has_key?(:reason)
               print "Reason? "
-              options[:reason] = STDIN.gets.chomp
+              options[:reason] = STDIN.gets.chomp.gsub("\n", " ")
             end
             request = Net::HTTP::Post.new(path)
             params = {'reason' => options[:reason]}

--- a/lib/litmus_paper/health.rb
+++ b/lib/litmus_paper/health.rb
@@ -31,7 +31,12 @@ module LitmusPaper
         when :down
           0
         when :health
-          @forced_reason.split("\n").last.to_i
+          forced_health = @forced_reason.split("\n").last.to_i
+
+          # This could potentially be argued differently, but I feel like forcing
+          # a health value != forcing up - if the measured health is less than the
+          # forced health, we should return the measured health.
+          measured_health < forced_health ? measured_health : forced_health
         end
       end
 

--- a/lib/litmus_paper/health.rb
+++ b/lib/litmus_paper/health.rb
@@ -19,9 +19,20 @@ module LitmusPaper
       @forced != :none
     end
 
+    def direction
+      @forced
+    end
+
     def value
       if forced?
-        return @forced == :up ? 100 : 0
+        return case @forced
+        when :up
+          100
+        when :down
+          0
+        when :health
+          @forced_reason.split("\n").last.to_i
+        end
       end
 
       measured_health

--- a/lib/litmus_paper/status_file.rb
+++ b/lib/litmus_paper/status_file.rb
@@ -10,6 +10,10 @@ module LitmusPaper
       new("global_up", :up)
     end
 
+    def self.global_health_file
+      new("global_health", :health)
+    end
+
     def self.service_down_file(service_name)
       new("#{service_name}_down", :down)
     end
@@ -18,12 +22,18 @@ module LitmusPaper
       new("#{service_name}_up", :up)
     end
 
+    def self.service_health_file(service_name)
+      new("#{service_name}_health", :health)
+    end
+
     def self.priority_check_order_for_service(service_name)
       [
         global_down_file,
         global_up_file,
+        global_health_file,
         service_down_file(service_name),
-        service_up_file(service_name)
+        service_up_file(service_name),
+        service_health_file(service_name),
       ]
     end
 
@@ -36,10 +46,11 @@ module LitmusPaper
       File.read(@path).chomp
     end
 
-    def create(reason)
+    def create(reason, health = nil)
       FileUtils.mkdir_p(File.dirname(@path))
       File.open(@path, 'w') do |file|
         file.puts(reason)
+        file.puts(health) if health
       end
     end
 

--- a/spec/litmus_paper/app_spec.rb
+++ b/spec/litmus_paper/app_spec.rb
@@ -51,6 +51,13 @@ describe LitmusPaper::App do
       last_response.body.should match(/\* another +0 +0 +Down for testing\n/)
       last_response.body.should match(/\* test +100 +0 +Up for testing\n/)
     end
+
+    it "includes the health value if health is forced" do
+      LitmusPaper.services['test'] = LitmusPaper::Service.new('test')
+      LitmusPaper::StatusFile.service_health_file("test").create("Forcing health", 88)
+      get "/"
+      last_response.body.should match(/Forcing health 88\n/)
+    end
   end
 
   describe "POST /up" do
@@ -81,6 +88,20 @@ describe LitmusPaper::App do
     end
   end
 
+  describe "POST /health" do
+    it "creates a global healthfile" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+
+      post "/health", :reason => "health for testing", :health => 88
+      last_response.status.should == 201
+
+      get "/test/status"
+      last_response.status.should == 200
+      last_response.body.should match(/health for testing 88/)
+    end
+  end
+
   describe "POST /:service/up" do
     it "creates a service specific upfile" do
       test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
@@ -92,6 +113,20 @@ describe LitmusPaper::App do
       get "/test/status"
       last_response.status.should == 200
       last_response.body.should match(/up for testing/)
+    end
+  end
+
+  describe "POST /:service/health" do
+    it "creates a service specific healthfile" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+
+      post "/test/health", :reason => "health for testing", :health => 88
+      last_response.status.should == 201
+
+      get "/test/status"
+      last_response.status.should == 200
+      last_response.body.should match(/health for testing 88/)
     end
   end
 
@@ -143,6 +178,35 @@ describe LitmusPaper::App do
     end
   end
 
+  describe "DELETE /health" do
+    it "removes the global healthfile" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+
+      post "/health", :reason => "health for testing", :health => 88
+      last_response.status.should == 201
+
+      get "/test/status"
+      last_response.status.should == 200
+      last_response.body.should match(/health for testing 88/)
+
+      delete "/health"
+      last_response.status.should == 200
+
+      get "/test/status"
+      last_response.should be_ok
+      last_response.body.should_not match(/health for testing 88/)
+    end
+
+    it "404s if there is no healthfile" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+
+      delete "/health"
+
+      last_response.status.should == 404
+    end
+  end
+
   describe "DELETE /:service/up" do
     it "removes a service specific upfile" do
       test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
@@ -160,6 +224,35 @@ describe LitmusPaper::App do
 
       get "/test/status"
       last_response.status.should == 503
+    end
+  end
+
+  describe "DELETE /:service/health" do
+    it "removes the service specific healthfile" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+
+      post "/test/health", :reason => "health for testing", :health => 88
+      last_response.status.should == 201
+
+      get "/test/status"
+      last_response.status.should == 200
+      last_response.body.should match(/health for testing 88/)
+
+      delete "/test/health"
+      last_response.status.should == 200
+
+      get "/test/status"
+      last_response.should be_ok
+      last_response.body.should_not match(/health for testing 88/)
+    end
+
+    it "404s if there is no healthfile" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+
+      delete "/test/health"
+
+      last_response.status.should == 404
     end
   end
 

--- a/spec/litmus_paper/app_spec.rb
+++ b/spec/litmus_paper/app_spec.rb
@@ -118,7 +118,7 @@ describe LitmusPaper::App do
 
   describe "POST /:service/health" do
     it "creates a service specific healthfile" do
-      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
       LitmusPaper.services['test'] = test_service
 
       post "/test/health", :reason => "health for testing", :health => 88
@@ -257,6 +257,33 @@ describe LitmusPaper::App do
   end
 
   describe "GET /:service/status" do
+    it "returns the forced health value for a healthy service" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_health_file("test").create("Forcing health", 88)
+
+      get "/test/status"
+      last_response.should be_ok
+      last_response.header["X-Health"].should == "88"
+      last_response.body.should match(/Health: 88/)
+      last_response.body.should match(/Measured Health: 100/)
+      last_response.header["X-Health-Forced"].should == "health"
+    end
+
+    it "returns the actualy health value for an unhealthy service when the measured health is less than the forced value" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_health_file("test").create("Forcing health", 88)
+
+      get "/test/status"
+      last_response.should_not be_ok
+      last_response.header["X-Health"].should == "0"
+      last_response.header["X-Health-Forced"].should == "health"
+      last_response.body.should match(/Health: 0/)
+      last_response.body.should match(/Measured Health: 0/)
+      last_response.body.should match(/Forcing health 88\n/)
+    end
+
     it "is successful when the service is passing" do
       test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
       LitmusPaper.services['test'] = test_service

--- a/spec/litmus_paper/cli/admin_spec.rb
+++ b/spec/litmus_paper/cli/admin_spec.rb
@@ -50,11 +50,11 @@ describe 'litmusctl' do
       status.should match(/for testing/)
     end
 
-    it "can create a global helpfile" do
+    it "can create a global healthfile" do
       _litmusctl('force health 88 -r "for testing"').should match("File created")
 
       status = _litmusctl('status test')
-      status.should match(/Health: 88/)
+      status.should match(/Health: 0/) # This service is actually failing so we'll get 0 back
       status.should match(/for testing 88/)
     end
 
@@ -70,7 +70,7 @@ describe 'litmusctl' do
       _litmusctl('force health 88 test -r "for testing"').should match("File created")
 
       status = _litmusctl('status test')
-      status.should match(/Health: 88/)
+      status.should match(/Health: 0/)
       status.should match(/for testing 88/)
     end
 

--- a/spec/litmus_paper/cli/admin_spec.rb
+++ b/spec/litmus_paper/cli/admin_spec.rb
@@ -50,6 +50,14 @@ describe 'litmusctl' do
       status.should match(/for testing/)
     end
 
+    it "can create a global helpfile" do
+      _litmusctl('force health 88 -r "for testing"').should match("File created")
+
+      status = _litmusctl('status test')
+      status.should match(/Health: 88/)
+      status.should match(/for testing 88/)
+    end
+
     it "creates a downfile" do
       _litmusctl('force down test -r "for testing"').should match("File created")
 
@@ -58,10 +66,26 @@ describe 'litmusctl' do
       status.should match(/for testing/)
     end
 
+    it "creates a healthfile" do
+      _litmusctl('force health 88 test -r "for testing"').should match("File created")
+
+      status = _litmusctl('status test')
+      status.should match(/Health: 88/)
+      status.should match(/for testing 88/)
+    end
+
     it 'removes an upfile for the service' do
       _litmusctl('force up test -r "for testing"').should match("File created")
       _litmusctl('force up test -d').should match("File deleted")
 
+      status = _litmusctl('status passing_test')
+      status.should match(/Health: \d\d/)
+      status.should_not match(/for testing/)
+    end
+
+    it "removes a healthfile for the service" do
+      _litmusctl('force health 88 test -r "for testing"').should match("File created")
+      _litmusctl('force health test -d').should match("File deleted")
       status = _litmusctl('status passing_test')
       status.should match(/Health: \d\d/)
       status.should_not match(/for testing/)


### PR DESCRIPTION
Previously, if you wanted to force a specific health measurement for
a service, you needed to change the configuration for that service to
include a constant metric at the value you wanted. This commit adds
(albeit a bit hackishly) the ability to specity an exact health level:

  litmusctl force health 88 -r "Because reasons"

...would then set the measured health of the service to 88.

This is sometimes useful if you want to slowly balance in/out a server,
and you want to do that via litmus.