### PR TITLE
Set a floor for CPU metric checks

### DIFF
--- a/lib/litmus_paper/metric/cpu_load.rb
+++ b/lib/litmus_paper/metric/cpu_load.rb
@@ -7,7 +7,7 @@ module LitmusPaper
       end
 
       def current_health
-        [@weight - (@weight * load_average / processor_count), 0].max
+        [@weight - (@weight * load_average / processor_count), 1].max
       end
 
       def processor_count

--- a/spec/litmus_paper/metric/cpu_load_spec.rb
+++ b/spec/litmus_paper/metric/cpu_load_spec.rb
@@ -8,10 +8,10 @@ describe LitmusPaper::Metric::CPULoad do
       cpu_load.current_health.should == 30
     end
 
-    it "is zero when the load is above one per core" do
+    it "is one when the load is above one per core" do
       facter = StubFacter.new({"processorcount" => "4", "loadaverage" => "20.00 11.40 10.00"})
       cpu_load = LitmusPaper::Metric::CPULoad.new(50, facter)
-      cpu_load.current_health.should == 0
+      cpu_load.current_health.should == 1
     end
   end
 


### PR DESCRIPTION
It's unwise to allow a service to go to zero health. In a cluster
situation, you run the very real chance of all services unbalancing.