### PR TITLE
Add HAProxy agent-check support

### DIFF
--- a/bin/litmus-agent-check
+++ b/bin/litmus-agent-check
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'litmus_paper'
+require 'litmus_paper/cli/agent_check'
+
+LitmusPaper::CLI::AgentCheck.new.run(ARGV)

--- a/lib/litmus_paper/cli/agent_check.rb
+++ b/lib/litmus_paper/cli/agent_check.rb
@@ -1,0 +1,71 @@
+module LitmusPaper
+  module CLI
+    class AgentCheck
+
+      def parse_args(args)
+        options = {}
+        optparser = OptionParser.new do |opts|
+          opts.on("-s", "--service SERVICE", "Service to check") do |s|
+            options[:service] = s
+          end
+          opts.on("-c", "--config CONFIG", "Path to config file") do |c|
+            options[:config] = c
+          end
+          opts.on("-h", "--help", "Help text") do |h|
+            options[:help] = h
+          end
+        end
+
+        begin
+          optparser.parse! args
+        rescue OptionParser::InvalidOption => e
+          puts e
+          puts optparser
+          exit 1
+        end
+
+        if options[:help]
+          puts optparser
+          exit 0
+        end
+
+        if !options.has_key?(:service)
+          puts "Error: `-s SERVICE` required"
+          puts optparser
+          exit 1
+        end
+        options
+      end
+
+      def output_service_status(service, stdout)
+        output = []
+        health = LitmusPaper.check_service(service)
+        if health.nil?
+          output << "failed#NOT_FOUND"
+        else
+          case health.direction
+          when :up, :health
+            output << "ready"
+          when :down
+            output << "drain"
+          when :none
+            if health.ok?
+              output << "ready"
+            else
+              output << "down"
+            end
+          end
+          output << "#{health.value.to_s}%"
+        end
+        stdout.printf("%s\r\n", output.join("\t"))
+      end
+
+      def run(args)
+        options = parse_args(args)
+        LitmusPaper.configure(options[:config])
+        output_service_status(options[:service], $stdout)
+      end
+
+    end
+  end
+end

--- a/spec/litmus_paper/cli/agent_check_spec.rb
+++ b/spec/litmus_paper/cli/agent_check_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'litmus_paper/cli/agent_check'
+
+describe LitmusPaper::CLI::AgentCheck do
+  before :each do
+    LitmusPaper.configure(TEST_CONFIG)
+  end
+
+  def agent_check(service)
+    output = StringIO.new
+    LitmusPaper::CLI::AgentCheck.new.output_service_status(service, output)
+    output.rewind
+    output.readline
+  end
+
+  describe "output_service_status" do
+    it "returns the forced health value for a healthy service" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_health_file("test").create("Forcing health", 88)
+      agent_check("test").should == "ready\t88%\r\n"
+    end
+
+    it "returns the actual health value for an unhealthy service when the measured health is less than the forced value" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_health_file("test").create("Forcing health", 88)
+      agent_check("test").should == "ready\t0%\r\n"
+    end
+
+    it "is 'ready' when the service is passing" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      agent_check("test").should == "ready\t100%\r\n"
+    end
+
+    it "is 'down' when the check fails" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      agent_check("test").should == "down\t0%\r\n"
+    end
+
+    it "is 'failed' when the service is unknown" do
+      agent_check("unknown").should == "failed#NOT_FOUND\r\n"
+    end
+
+    it "is 'drain' when an up file and down file exists" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_up_file("test").create("Up for testing")
+      LitmusPaper::StatusFile.service_down_file("test").create("Down for testing")
+      agent_check("test").should == "drain\t0%\r\n"
+    end
+
+    it "is 'drain' when a global down file and up file exists" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.global_down_file.create("Down for testing")
+      LitmusPaper::StatusFile.global_up_file.create("Up for testing")
+      agent_check("test").should == "drain\t0%\r\n"
+    end
+
+    it "is 'ready' when an up file exists" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.service_up_file("test").create("Up for testing")
+      agent_check("test").should == "ready\t100%\r\n"
+    end
+
+    it "is 'drain' when a global down file exists" do
+      test_service = LitmusPaper::Service.new('test', [AlwaysAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.global_down_file.create("Down for testing")
+      agent_check("test").should == "drain\t0%\r\n"
+    end
+
+    it "is 'ready' when a global up file exists" do
+      test_service = LitmusPaper::Service.new('test', [NeverAvailableDependency.new], [LitmusPaper::Metric::ConstantMetric.new(100)])
+      LitmusPaper.services['test'] = test_service
+      LitmusPaper::StatusFile.global_up_file.create("Up for testing")
+      agent_check("test").should == "ready\t100%\r\n"
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new program litmus-agent-check which may be used as
an agent check for HAProxy. This program would need to be run under an
inetd type server. Given that litmus runs its checks inline with its
call this method provides a simple way to add agent-check support. An
alternative would be to add a TCP server to litmus, but that has few
advantages over a well tested server such as xinetd. The litmus states
are mirrored with as much fidelity as possible to the agent-check
states.

Example output:

  ready   100%

Example config for xinetd:

  service internet_health
  {
    disable     = no
    socket_type = stream
    protocol    = tcp
    port        = 9191
    user        = agent-check
    wait        = no
    server      = /usr/bin/litmus-agent-check
    server_args = -s isp
    type        = UNLISTED
    instances   = 10
  }

HAProxy agent-check documentation:

https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#5.2-agent-check