### PR TITLE
Add `force remove` command line option to remove health forces

### DIFF
--- a/lib/litmus_paper/cli/admin/force.rb
+++ b/lib/litmus_paper/cli/admin/force.rb
@@ -9,7 +9,7 @@ module LitmusPaper
         def self.build_request(options, args)
           options.merge! _default_options
           opt_parser = _extend_default_parser(options) do |opts|
-            opts.banner = "Usage: litmusctl force <up|down|health N> [service] [options]"
+            opts.banner = "Usage: litmusctl force [remove] <up|down|health N> [service] [options]"
             opts.on("-d", "--delete", "Remove status file") do
               options[:delete] = true
             end
@@ -19,6 +19,10 @@ module LitmusPaper
           end
 
           opt_parser.parse! args
+          if args[0] == "remove"
+            options[:delete] = true
+            args.shift
+          end
           if args[0] == "health" && !options[:delete]
             direction, value, service = args
           else

--- a/spec/litmus_paper/cli/admin_spec.rb
+++ b/spec/litmus_paper/cli/admin_spec.rb
@@ -83,9 +83,33 @@ describe 'litmusctl' do
       status.should_not match(/for testing/)
     end
 
+    it "removes an upfile for the service with 'remove'" do
+      _litmusctl('force up test -r "for testing"').should match("File created")
+      _litmusctl('force remove up test').should match("File deleted")
+      status = _litmusctl('status passing_test')
+      status.should match(/Health: \d\d/)
+      status.should_not match(/for testing/)
+    end
+
     it "removes a healthfile for the service" do
       _litmusctl('force health 88 test -r "for testing"').should match("File created")
       _litmusctl('force health test -d').should match("File deleted")
+      status = _litmusctl('status passing_test')
+      status.should match(/Health: \d\d/)
+      status.should_not match(/for testing/)
+    end
+
+    it "removes a healthfile for the service with 'remove'" do
+      _litmusctl('force health 88 test -r "for testing"').should match("File created")
+      _litmusctl('force remove health test').should match("File deleted")
+      status = _litmusctl('status passing_test')
+      status.should match(/Health: \d\d/)
+      status.should_not match(/for testing/)
+    end
+
+    it "removes a downfile for the service with 'remove'" do
+      _litmusctl('force down test -r "for testing"').should match("File created")
+      _litmusctl('force remove down test').should match("File deleted")
       status = _litmusctl('status passing_test')
       status.should match(/Health: \d\d/)
       status.should_not match(/for testing/)


### PR DESCRIPTION
A major complaint from users of litmus are that it's incredibly
non-intuitive to remove a forced health (see issue #4). Most people will
just assume `force up` is the opposite to `force down`, putting their
service's health in the wrong state.

Hopefully, adding a `force remove` will make it easier for users to
perform their expected actions.