### PR TITLE
Always report Measured Health

### DIFF
--- a/lib/litmus_paper/app.rb
+++ b/lib/litmus_paper/app.rb
@@ -45,6 +45,7 @@ module LitmusPaper
 
         headers = {"X-Health" => health.value.to_s}
         body = "Health: #{health.value}\n"
+        body << "Measured Health: #{health.measured_health}\n"
         if health.forced?
           if health.direction == :health
             status = "health"
@@ -52,7 +53,6 @@ module LitmusPaper
           else
             reason = health.forced_reason
           end
-          body << "Measured Health: #{health.measured_health}\n"
           body << "Forced Reason: #{reason}\n"
         end
         body << health.summary

--- a/lib/litmus_paper/version.rb
+++ b/lib/litmus_paper/version.rb
@@ -1,3 +1,3 @@
 module LitmusPaper
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end

--- a/spec/litmus_paper/app_spec.rb
+++ b/spec/litmus_paper/app_spec.rb
@@ -297,6 +297,7 @@ describe LitmusPaper::App do
       last_response.header["X-Health"].should == "100"
       last_response.header.should_not have_key("X-Health-Forced")
       last_response.body.should match(/Health: 100/)
+      last_response.body.should match(/Measured Health: 100/)
       last_response.body.should match(/AlwaysAvailableDependency: OK/)
       last_response.body.should include("Metric::ConstantMetric(100): 100")
     end
@@ -311,6 +312,7 @@ describe LitmusPaper::App do
       last_response.header["Content-Type"].should == "text/plain"
       last_response.header["X-Health"].should == "0"
       last_response.body.should match(/Health: 0/)
+      last_response.body.should match(/Measured Health: 0/)
     end
 
     it "is 'not found' when the service is unknown" do


### PR DESCRIPTION
Currently, /:service/status only reports measured health if it is forced up
or down. This can make parsing output more difficult for programs that
always expect to see measured health. This commit makes sure
/:service/status always reports measured health for a more consistent
output format.

This also bumps the version from 0.9.4 to 0.9.5.