### PR TITLE
Remove popen4 dependency

### DIFF
--- a/lib/litmus_paper.rb
+++ b/lib/litmus_paper.rb
@@ -16,7 +16,6 @@ require 'colorize'
 #
 require 'resolv-replace'
 
-require 'popen4'
 require 'sinatra/base'
 require 'facter'
 require 'remote_syslog_logger'

--- a/lib/litmus_paper/dependency/script.rb
+++ b/lib/litmus_paper/dependency/script.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module LitmusPaper
   module Dependency
     class Script
@@ -9,23 +11,27 @@ module LitmusPaper
       end
 
       def available?
-        Timeout.timeout(@timeout) do
-          script_stdout = script_stderr = nil
-          script_status = POpen4.popen4(@command) do |stdout, stderr, stdin, pid|
-            @script_pid = pid
-            script_stdout = stdout.read.strip
-            script_stderr = stderr.read.strip
+        script_status = script_stdout = script_stderr = nil
+        Open3.popen3(@command, :pgroup=>true) do |stdin, stdout, stderr, wait_thr|
+          @script_pid = wait_thr.pid
+          thstderr = Thread.new { stderr.read }
+          thstdout = Thread.new { stdout.read }
+          if !wait_thr.join(@timeout) # wait thread does not end within timeout
+            kill_and_reap_script(-@script_pid) # kill the process group
+            raise Timeout::Error
           end
-          unless script_status.success?
-            LitmusPaper.logger.info("Available check to #{@command} failed with status #{$CHILD_STATUS.exitstatus}")
-            LitmusPaper.logger.info("Failed stdout: #{script_stdout}")
-            LitmusPaper.logger.info("Failed stderr: #{script_stderr}")
-          end
-          script_status.success?
+          script_stderr = thstderr.value
+          script_stdout = thstdout.value
+          script_status = wait_thr.value
         end
+        unless script_status.success?
+          LitmusPaper.logger.info("Available check to #{@command} failed with status #{script_status.exitstatus}")
+          LitmusPaper.logger.info("Failed stdout: #{script_stdout}")
+          LitmusPaper.logger.info("Failed stderr: #{script_stderr}")
+        end
+        script_status.success?
       rescue Timeout::Error
         LitmusPaper.logger.info("Timeout running command: '#{@command}'")
-        kill_and_reap_script(@script_pid)
         false
       rescue => e
         LitmusPaper.logger.info("Available check to #{@uri} failed with #{e.message}")

--- a/litmus_paper.gemspec
+++ b/litmus_paper.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sinatra", "~> 1.3.2"
   gem.add_dependency "facter", "~> 1.7.5"
   gem.add_dependency "remote_syslog_logger", "~> 1.0.3"
-  gem.add_dependency "popen4", "~> 0.1.2"
   gem.add_dependency "unicorn", "~> 4.6.2"
   gem.add_dependency "colorize"
 

--- a/spec/litmus_paper/dependency/script_spec.rb
+++ b/spec/litmus_paper/dependency/script_spec.rb
@@ -7,8 +7,28 @@ describe LitmusPaper::Dependency::Script do
       check.should be_available
     end
 
+    it "is true when the script returns a lot of data" do
+      check = LitmusPaper::Dependency::Script.new("dd if=/dev/urandom bs=1M count=1|base64")
+      check.should be_available
+    end
+
     it "is false when the script returns 1" do
       check = LitmusPaper::Dependency::Script.new("false")
+      check.should_not be_available
+    end
+
+    it "logs stdout and stderr when it fails" do
+      check = LitmusPaper::Dependency::Script.new("echo Hello && echo Goodbye 1>&2 && false")
+      count = 0
+      logs = [
+        "Available check to echo Hello && echo Goodbye 1>&2 && false failed with status 1",
+        "Failed stdout: Hello\n",
+        "Failed stderr: Goodbye\n",
+      ]
+      LitmusPaper.logger.should_receive(:info).exactly(3).times do |log|
+        log.should == logs[count]
+        count += 1
+      end
       check.should_not be_available
     end
 


### PR DESCRIPTION
Ruby 1.9 has open3 with a thread to wait on the pid, so we don't need
popen4 to get the correct timeout behavior.