### PR TITLE
Add caching to health checks

### DIFF
--- a/lib/litmus_paper.rb
+++ b/lib/litmus_paper.rb
@@ -14,6 +14,7 @@ require 'forwardable'
 
 require 'remote_syslog_logger'
 
+require 'litmus_paper/cache'
 require 'litmus_paper/configuration'
 require 'litmus_paper/configuration_file'
 require 'litmus_paper/dependency/file_contents'
@@ -35,7 +36,7 @@ require 'litmus_paper/version'
 module LitmusPaper
   class << self
     extend Forwardable
-    def_delegators :@config, :services, :data_directory, :port
+    def_delegators :@config, :services, :data_directory, :port, :cache_location, :cache_ttl
     attr_accessor :logger
   end
 

--- a/lib/litmus_paper/cache.rb
+++ b/lib/litmus_paper/cache.rb
@@ -1,0 +1,33 @@
+require 'yaml'
+
+module LitmusPaper
+  class Cache
+    def initialize(location, namespace, ttl)
+      @path = File.join(location, namespace)
+      @ttl = ttl
+
+      FileUtils.mkdir_p(@path)
+    end
+
+    def set(key, value)
+      return unless @ttl > 0
+      File.open(File.join(@path, key), "a") do |f|
+        f.flock(File::LOCK_EX)
+        f.rewind
+        f.write("#{Time.now.to_f + @ttl} #{YAML::dump(value)}")
+        f.flush
+        f.truncate(f.pos)
+      end
+    end
+
+    def get(key)
+      return unless File.exists?(File.join(@path, key))
+      File.open(File.join(@path, key), "r") do |f|
+        f.flock(File::LOCK_SH)
+        entry = f.read
+        expires_at, value = entry.split(" ", 2)
+        expires_at.to_f < Time.now.to_f ? nil : YAML::load(value)
+      end
+    end
+  end
+end

--- a/lib/litmus_paper/configuration.rb
+++ b/lib/litmus_paper/configuration.rb
@@ -1,4 +1,11 @@
 module LitmusPaper
-  class Configuration < Struct.new(:port, :data_directory, :services)
+  fields = [
+    :port,
+    :data_directory,
+    :services,
+    :cache_location,
+    :cache_ttl
+  ]
+  class Configuration < Struct.new(*fields)
   end
 end

--- a/lib/litmus_paper/configuration_file.rb
+++ b/lib/litmus_paper/configuration_file.rb
@@ -5,13 +5,21 @@ module LitmusPaper
       @services = {}
       @port = 9292
       @data_directory = "/etc/litmus"
+      @cache_location = "/run/shm"
+      @cache_ttl = -1
     end
 
     def evaluate(file = @config_file_path)
       LitmusPaper.logger.info "Loading file #{file}"
       config_contents = File.read(file)
       instance_eval(config_contents)
-      LitmusPaper::Configuration.new(@port, @data_directory, @services)
+      LitmusPaper::Configuration.new(
+        @port,
+        @data_directory,
+        @services,
+        @cache_location,
+        @cache_ttl
+      )
     end
 
     def include_files(glob_pattern)
@@ -35,6 +43,14 @@ module LitmusPaper
       service = Service.new(name.to_s)
       block.call(service)
       @services[name.to_s] = service
+    end
+
+    def cache_location(location)
+      @cache_location = location
+    end
+
+    def cache_ttl(ttl)
+      @cache_ttl = ttl
     end
   end
 end

--- a/spec/litmus_paper/cache_spec.rb
+++ b/spec/litmus_paper/cache_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe LitmusPaper::Cache do
+  before(:each) do
+    @location = "/tmp/litmus_cache"
+    @namespace = "test_cache"
+    @ttl = -1
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(@location)
+  end
+
+  describe "initialize" do
+    it "creates the directory structure" do
+      File.exists?(@location).should be false
+      LitmusPaper::Cache.new(@location, @namespace, @ttl)
+      File.exists?(File.join(@location, @namespace)).should be true
+    end
+  end
+
+  describe "get" do
+    it "returns false if the key was not previously set" do
+      cache = LitmusPaper::Cache.new(@location, @namespace, @ttl)
+      cache.get("non-existant-key").should be_nil
+    end
+
+    context "when called with fresh entry" do
+      it "returns the value set" do
+        cache = LitmusPaper::Cache.new(@location, @namespace, 10)
+        cache.set("key", "some value")
+        cache.get("key").should == "some value"
+      end
+    end
+
+    context "when called with expired entry" do
+      it "returns nil" do
+        cache = LitmusPaper::Cache.new(@location, @namespace, -1)
+        cache.set("key", "some value")
+        cache.get("key").should be_nil
+      end
+    end
+  end
+
+  describe "set" do
+    context "when called with non-positive ttl" do
+      it "does not store the value" do
+        key = "key"
+        cache = LitmusPaper::Cache.new(@location, @namespace, 0)
+        cache.set(key, "some value")
+        File.exists?(File.join(@location, @namespace, key)).should be false
+      end
+    end
+
+    context "when called with positive ttl" do
+      it "stores the value" do
+        key = "key"
+        cache = LitmusPaper::Cache.new(@location, @namespace, 1)
+        cache.set(key, "some value")
+        File.exists?(File.join(@location, @namespace, key)).should be true
+      end
+    end
+
+    it "expires the entry after the ttl" do
+      key = "key"
+      ttl = 0.01
+      cache = LitmusPaper::Cache.new(@location, @namespace, ttl)
+      cache.set(key, "some value")
+      cache.get(key).should == "some value"
+      sleep ttl
+      cache.get(key).should be_nil
+    end
+  end
+end

--- a/spec/litmus_paper/configuration_file_spec.rb
+++ b/spec/litmus_paper/configuration_file_spec.rb
@@ -19,6 +19,18 @@ describe LitmusPaper::ConfigurationFile do
       config = config_file.evaluate
       config.data_directory.should == "/tmp/litmus_paper"
     end
+
+    it "configures the cache_location" do
+      config_file = LitmusPaper::ConfigurationFile.new(TEST_CONFIG)
+      config = config_file.evaluate
+      config.cache_location.should == "/tmp/litmus_paper_cache"
+    end
+
+    it "configures the cache_ttl" do
+      config_file = LitmusPaper::ConfigurationFile.new(TEST_CONFIG)
+      config = config_file.evaluate
+      config.cache_ttl.should == -1
+    end
   end
 
   describe "include_files" do

--- a/spec/support/test.config
+++ b/spec/support/test.config
@@ -4,6 +4,9 @@ port 9293
 
 data_directory "/tmp/litmus_paper"
 
+cache_location "/tmp/litmus_paper_cache"
+cache_ttl -1
+
 service :test do |s|
   s.depends Dependency::HTTP, "http://localhost/heartbeat"
 

--- a/spec/support/test.reload.config
+++ b/spec/support/test.reload.config
@@ -4,6 +4,9 @@ port 9293
 
 data_directory "/tmp/litmus_paper"
 
+cache_location "/tmp/litmus_paper_cache"
+cache_ttl -1
+
 service :foo do |s|
   s.depends Dependency::HTTP, "http://localhost/heartbeat"
 


### PR DESCRIPTION
## What

This PR adds a caching layer to Litmus Paper for health checks. The caching is disabled by default and can be enabled by setting the desired cache_ttl via config file.

## Why

This allows multiple load balancers to run health checks for the same service and prevent the service from being overwhelmed by health check requests.