### PR TITLE
Add caching to the agent-check-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Here are all the types of checks currently implemented:
 
 Litmus paper can also report health checks in HAProxy agent check format. The agent check functionality takes the health data from a service health check, and exposes it on a different port in the format HAProxy expects.
 
-There are no configuration files for the agent check, since all options are specified on the command line.
+There are no additional configuration files for the agent check, since all options are specified on the command line. Services are configured as normal litmus services as described above.
 
 ```
 Usage: litmus-agent-check [options]

--- a/lib/litmus_paper/agent_check_handler.rb
+++ b/lib/litmus_paper/agent_check_handler.rb
@@ -1,8 +1,19 @@
 module LitmusPaper
   class AgentCheckHandler
     def self.handle(service)
+      @cache ||= LitmusPaper::Cache.new(
+        LitmusPaper.cache_location,
+        "litmus_cache",
+        LitmusPaper.cache_ttl
+      )
       output = []
-      health = LitmusPaper.check_service(service)
+
+      health = @cache.get(service)
+      @cache.set(
+        service,
+        health = LitmusPaper.check_service(service)
+      ) unless health
+
       if health.nil?
         output << "failed#NOT_FOUND"
       else

--- a/lib/litmus_paper/agent_check_handler.rb
+++ b/lib/litmus_paper/agent_check_handler.rb
@@ -3,16 +3,18 @@ module LitmusPaper
     def self.handle(service)
       @cache ||= LitmusPaper::Cache.new(
         LitmusPaper.cache_location,
-        "litmus_cache",
+        "litmus_agent_cache",
         LitmusPaper.cache_ttl
       )
       output = []
 
       health = @cache.get(service)
-      @cache.set(
-        service,
-        health = LitmusPaper.check_service(service)
-      ) unless health
+      if !health
+        @cache.set(
+          service,
+          health = LitmusPaper.check_service(service)
+        )
+      end
 
       if health.nil?
         output << "failed#NOT_FOUND"


### PR DESCRIPTION
This adds an instance-level cache in the same location as other
litmus caches (to read the same cache as the normal web server).
This should increase performance of the tcp agent-check-server.

The testing is pretty nasty, largely because I can't do rspec very
well.

Closes #27 