### PR TITLE
Fix memory leak / broken caching functionality

### DIFF
--- a/lib/litmus_paper/cache.rb
+++ b/lib/litmus_paper/cache.rb
@@ -11,12 +11,18 @@ module LitmusPaper
 
     def set(key, value)
       return unless @ttl > 0
-      File.open(File.join(@path, key), "a") do |f|
-        f.flock(File::LOCK_EX)
-        f.rewind
-        f.write("#{Time.now.to_f + @ttl} #{YAML::dump(value)}")
-        f.flush
-        f.truncate(f.pos)
+      filepath = File.join(@path, key)
+      begin
+        File.open(filepath, "r+") do |f|
+          f.flock(File::LOCK_EX)
+          f.rewind
+          f.write("#{Time.now.to_f + @ttl} #{YAML::dump(value)}")
+          f.flush
+          f.truncate(f.pos)
+        end
+      rescue Errno::ENOENT => e
+        File.open(filepath, "a") {}
+        set(key, value)
       end
     end
 

--- a/spec/litmus_paper/cache_spec.rb
+++ b/spec/litmus_paper/cache_spec.rb
@@ -71,7 +71,7 @@ describe LitmusPaper::Cache do
       cache.get(key).should be_nil
     end
 
-    it "it works when setting multiple entries" do
+    it "works when setting multiple entries" do
       key = "key"
       cache = LitmusPaper::Cache.new(@location, @namespace, 1)
       cache.set(key, "some value")

--- a/spec/litmus_paper/cache_spec.rb
+++ b/spec/litmus_paper/cache_spec.rb
@@ -70,5 +70,13 @@ describe LitmusPaper::Cache do
       sleep ttl
       cache.get(key).should be_nil
     end
+
+    it "it works when setting multiple entries" do
+      key = "key"
+      cache = LitmusPaper::Cache.new(@location, @namespace, 1)
+      cache.set(key, "some value")
+      cache.set(key, "other value")
+      cache.get(key).should == "other value"
+    end
   end
 end


### PR DESCRIPTION
## What

This PR changes the File open mode for cached entries to `r+` from `a`.  See the "why" section for why this is important. Due to the file mode change, we must also handle the possibility that the file does not exist yet.

## Why

There is a bug with the original caching implementation, rendering it both useless and growing in memory/disk usage without bound. The initial implementation opens the file in append mode, grabs a lock, and then overwrites the contents. It does this (as opposed to using write mode) so that it does not clear the contents before grabbing the lock (in which case read processes could read an empty file when there should be a cached value). 

The problem is that opening a file in append mode, does not allow you to seek through the file; it ignores any seeking and only writes contents to the end. Therefore we must open the file in `r+` mode to not truncate the file, but to be able to seek through the file and modify contents.