### PR TITLE
Get tests passing on new pairing machines

### DIFF
--- a/spec/litmus_paper/agent_check_server_spec.rb
+++ b/spec/litmus_paper/agent_check_server_spec.rb
@@ -11,7 +11,7 @@ describe LitmusPaper::AgentCheckServer do
     port_open = false
     while ! port_open do
       begin
-        TCPSocket.new('localhost', 9191)
+        TCPSocket.new('127.0.0.1', 9191)
       rescue StandardError => e
         sleep 0.1
         next
@@ -26,12 +26,12 @@ describe LitmusPaper::AgentCheckServer do
 
   describe "The agent-check text protocol" do
     it "returns the health from a passing test" do
-      TCPSocket.open('localhost', 9191) do |s|
+      TCPSocket.open('127.0.0.1', 9191) do |s|
         s.gets.should match(/ready\tup\t\d+%\r\n/)
       end
     end
     it "returns the health from a failing test" do
-      TCPSocket.open('localhost', 9192) do |s|
+      TCPSocket.open('127.0.0.1', 9192) do |s|
         s.gets.should match(/down\t0%\r\n/)
       end
     end

--- a/spec/litmus_paper/metric/internet_health_spec.rb
+++ b/spec/litmus_paper/metric/internet_health_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe LitmusPaper::Dependency::TCP do
+describe LitmusPaper::Metric::InternetHealth do
 
   describe "#current_health" do
     before(:all) do

--- a/spec/litmus_paper/metric/internet_health_spec.rb
+++ b/spec/litmus_paper/metric/internet_health_spec.rb
@@ -85,11 +85,11 @@ describe LitmusPaper::Metric::InternetHealth do
       internet_health = LitmusPaper::Metric::InternetHealth.new(
         100,
         [
-          "127.0.0.1:6000",
-          "127.0.0.1:6001",
           "127.0.0.1:6002",
           "127.0.0.1:6003",
           "127.0.0.1:6004",
+          "127.0.0.1:6005",
+          "127.0.0.1:6006",
         ],
       )
       internet_health.current_health.should == 0


### PR DESCRIPTION
* vnc is using port 6001 for me, and a test relies on it being closed.  
* I'm not exactly sure why, but on the new pairing machines it will not establish a connection via localhost. 

@lollipopman @ahayworth 