### PR TITLE
Add active and queued requests to text output of unix socket metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ Here are all the types of checks currently implemented:
 
 - `unix_socket_utilization` (`Metric::UnixSocketUtilitization`): Compares the number of active, queued requests against the maximum number of expected connections, [see](lib/litmus_paper/metric/unix_socket_utilization.rb) for the implementation of the algorithm.
   * weight (0-100)
-  * socket_path (path on the filesystem where the socket is located)
   * maxconn (maximum number of concurrent connection the server backing the socket is supposed to handle)
+  * active (number of requests actively being serviced at this point in time)
+  * queued (number of requests in the queue at this point in time not yet picked up by a worker)
+  * socket_path (path on the filesystem where the socket is located)
 
 - `big_brother_service` (`Metric::BigBrotherService`): Used in conjunction with [Big Brother](https://github.com/braintree/big_brother), reports health based on the overall health of another load balanced service.
   * service

--- a/README.md
+++ b/README.md
@@ -178,10 +178,8 @@ Here are all the types of checks currently implemented:
 
 - `unix_socket_utilization` (`Metric::UnixSocketUtilitization`): Compares the number of active, queued requests against the maximum number of expected connections, [see](lib/litmus_paper/metric/unix_socket_utilization.rb) for the implementation of the algorithm.
   * weight (0-100)
-  * maxconn (maximum number of concurrent connection the server backing the socket is supposed to handle)
-  * active (number of requests actively being serviced at this point in time)
-  * queued (number of requests in the queue at this point in time not yet picked up by a worker)
   * socket_path (path on the filesystem where the socket is located)
+  * maxconn (maximum number of concurrent connection the server backing the socket is supposed to handle)
 
 - `big_brother_service` (`Metric::BigBrotherService`): Used in conjunction with [Big Brother](https://github.com/braintree/big_brother), reports health based on the overall health of another load balanced service.
   * service

--- a/lib/litmus_paper/metric/unix_socket_utilization.rb
+++ b/lib/litmus_paper/metric/unix_socket_utilization.rb
@@ -28,7 +28,7 @@ module LitmusPaper
       end
 
       def to_s
-        "Metric::UnixSocketUtilitization(weight: #{@weight}, maxconn: #{@maxconn}, path: #{@socket_path})"
+        "Metric::UnixSocketUtilitization(weight: #{@weight}, maxconn: #{@maxconn}, active: #{_stats.active.to_i}, queued: #{_stats.queued.to_i}, path: #{@socket_path})"
       end
     end
   end

--- a/lib/litmus_paper/metric/unix_socket_utilization.rb
+++ b/lib/litmus_paper/metric/unix_socket_utilization.rb
@@ -7,17 +7,21 @@ module LitmusPaper
         @weight = weight
         @socket_path = socket_path
         @maxconn = maxconn
+        @active = 0
+        @queued = 0
       end
 
       def current_health
         stats = _stats
-        if stats.queued == 0
+        @active = stats.active
+        @queued = stats.queued
+        if @queued == 0
           return @weight
         else
           return [
             @weight - (
-              (@weight * _stats.active.to_f) / (3 * @maxconn.to_f) +
-              (2 * @weight * _stats.queued.to_f) / (3 * @maxconn.to_f)
+              (@weight * @active.to_f) / (3 * @maxconn.to_f) +
+              (2 * @weight * @queued.to_f) / (3 * @maxconn.to_f)
             ), 1
           ].max
         end
@@ -28,7 +32,7 @@ module LitmusPaper
       end
 
       def to_s
-        "Metric::UnixSocketUtilitization(weight: #{@weight}, maxconn: #{@maxconn}, active: #{_stats.active.to_i}, queued: #{_stats.queued.to_i}, path: #{@socket_path})"
+        "Metric::UnixSocketUtilitization(weight: #{@weight}, maxconn: #{@maxconn}, active: #{@active.to_i}, queued: #{@queued.to_i}, path: #{@socket_path})"
       end
     end
   end


### PR DESCRIPTION
The UNIX socket metric makes use of active and queued socket connections
as part of calculating the final weight. Those active and queued metrics
can be valuable as they provide insight into the number of received but
not-yet processed requests. By exposing those metrics in the text output
detail, other utilities can extract that information from outside the
host running the service. This can be especially useful when the service
is running in a container, it allows services outside the container such
as monitoring/metrics agents to collect this information without needing
direct access to the host or container itself.

These metrics are also valuable for application of some queuing theory
formulas, such as Little's Law. Active + Queued requests provide the L
in Little's formula. And since the metric also exposes the maximum
number of connections, this allows a third-party service such as a
monitoring agent to use (active + queued) / max to calculate how close
to maximum utilization the service running in the container is.