### PR TITLE
Add a metrics endpoint that provides service-level information

### DIFF
--- a/lib/litmus_paper/app.rb
+++ b/lib/litmus_paper/app.rb
@@ -97,6 +97,17 @@ module LitmusPaper
       _create_status_file(StatusFile.service_up_file(params[:service]))
     end
 
+    get "/:service/metrics" do
+      timestamp = (Time.now.utc.to_f * 1000).to_i
+      service = LitmusPaper.services[params[:service]]
+      metrics = service.checks.map do |check|
+        check.stats.map do |key, value|
+          %(#{key}{service="#{params[:service]}"} #{value} #{timestamp})
+        end.join("\n")
+      end
+      _text 200, metrics.join("\n") + "\n"
+    end
+
     get "/test/error" do
       raise "an error"
     end

--- a/lib/litmus_paper/metric/big_brother_service.rb
+++ b/lib/litmus_paper/metric/big_brother_service.rb
@@ -14,6 +14,10 @@ module LitmusPaper
         end
       end
 
+      def stats
+        {}
+      end
+
       def to_s
         "Metric::BigBrotherService(#{@service})"
       end

--- a/lib/litmus_paper/metric/constant_metric.rb
+++ b/lib/litmus_paper/metric/constant_metric.rb
@@ -9,6 +9,10 @@ module LitmusPaper
         @weight
       end
 
+      def stats
+        {}
+      end
+
       def to_s
         "Metric::ConstantMetric(#{@weight})"
       end

--- a/lib/litmus_paper/metric/cpu_load.rb
+++ b/lib/litmus_paper/metric/cpu_load.rb
@@ -24,6 +24,12 @@ module LitmusPaper
         File.read('/proc/loadavg').split(' ').first.to_f
       end
 
+      def stats
+        {
+          :cpu_load_average => load_average,
+        }
+      end
+
       def to_s
         "Metric::CPULoad(#{@weight})"
       end

--- a/lib/litmus_paper/metric/haproxy_backends_health.rb
+++ b/lib/litmus_paper/metric/haproxy_backends_health.rb
@@ -25,6 +25,10 @@ module LitmusPaper
         ((up_weight / total_weight) * @weight).to_i
       end
 
+      def stats
+        {}
+      end
+
       def to_s
         "Metric::HaproxyBackendsHealth(#{@weight}, #{@cluster})"
       end

--- a/lib/litmus_paper/metric/internet_health.rb
+++ b/lib/litmus_paper/metric/internet_health.rb
@@ -32,6 +32,10 @@ module LitmusPaper
         health.to_i
       end
 
+      def stats
+        {}
+      end
+
       def to_s
         "Metric::InternetHealth(#{@weight}, #{@hosts.inspect}, #{@options.inspect})"
       end

--- a/lib/litmus_paper/metric/script.rb
+++ b/lib/litmus_paper/metric/script.rb
@@ -60,6 +60,10 @@ module LitmusPaper
         LitmusPaper.logger.info("Attempted to reap PID #{pid} but it has already been reaped (ECHILD)")
       end
 
+      def stats
+        {}
+      end
+
       def to_s
         "Metric::Script(#{@command}, #{@weight})"
       end

--- a/lib/litmus_paper/metric/unix_socket_utilization.rb
+++ b/lib/litmus_paper/metric/unix_socket_utilization.rb
@@ -7,32 +7,31 @@ module LitmusPaper
         @weight = weight
         @socket_path = socket_path
         @maxconn = maxconn
-        @active = 0
-        @queued = 0
       end
 
       def current_health
         stats = _stats
-        @active = stats.active
-        @queued = stats.queued
-        if @queued == 0
+
+        if stats.queued == 0
           return @weight
-        else
-          return [
-            @weight - (
-              (@weight * @active.to_f) / (3 * @maxconn.to_f) +
-              (2 * @weight * @queued.to_f) / (3 * @maxconn.to_f)
-            ), 1
-          ].max
         end
+
+        [
+          @weight - (
+            (@weight * stats.active.to_f) / (3 * @maxconn.to_f) +
+            (2 * @weight * stats.queued.to_f) / (3 * @maxconn.to_f)
+          ),
+          1
+        ].max
       end
 
       def stats
-        current_health
+        stats = _stats
+
         {
-          :socket_active => @active,
-          :socket_queued => @queued,
-          :socket_utilization => ((@queued / @maxconn.to_f) * 100).round,
+          :socket_active => stats.active,
+          :socket_queued => stats.queued,
+          :socket_utilization => ((stats.queued / @maxconn.to_f) * 100).round,
         }
       end
 

--- a/lib/litmus_paper/metric/unix_socket_utilization.rb
+++ b/lib/litmus_paper/metric/unix_socket_utilization.rb
@@ -27,6 +27,15 @@ module LitmusPaper
         end
       end
 
+      def stats
+        current_health
+        {
+          :socket_active => @active,
+          :socket_queued => @queued,
+          :socket_utilization => ((@queued / @maxconn.to_f) * 100).round,
+        }
+      end
+
       def _stats
         Raindrops::Linux.unix_listener_stats([@socket_path])[@socket_path]
       end

--- a/lib/litmus_paper/service.rb
+++ b/lib/litmus_paper/service.rb
@@ -1,5 +1,7 @@
 module LitmusPaper
   class Service
+    attr_reader :checks
+
     def initialize(name, dependencies = [], checks = [])
       @name = name
       @dependencies = dependencies

--- a/spec/litmus_paper/metric/cpu_load_spec.rb
+++ b/spec/litmus_paper/metric/cpu_load_spec.rb
@@ -50,6 +50,16 @@ describe LitmusPaper::Metric::CPULoad do
     end
   end
 
+  describe "#stats" do
+    it "reports metrics" do
+      File.should_receive(:read).with('/proc/loadavg').and_return("0.08 0.12 0.15 2/1190 9152\n")
+      cpu_load = LitmusPaper::Metric::CPULoad.new(50)
+      cpu_load.stats.should == {
+        :cpu_load_average => 0.08
+      }
+    end
+  end
+
   describe "#to_s" do
     it "is the check name and the maximum weight" do
       cpu_load = LitmusPaper::Metric::CPULoad.new(50)

--- a/spec/litmus_paper/metric/unix_socket_utilization_spec.rb
+++ b/spec/litmus_paper/metric/unix_socket_utilization_spec.rb
@@ -38,4 +38,22 @@ describe LitmusPaper::Metric::UnixSocketUtilitization do
       health.should == 1
     end
   end
+
+  describe "#stats" do
+    it "reports metrics" do
+      LitmusPaper::Metric::UnixSocketUtilitization.any_instance.stub(
+        :_stats => OpenStruct.new({:queued => 7, :active => 10}),
+      )
+      metric = LitmusPaper::Metric::UnixSocketUtilitization.new(
+        100,
+        '/var/run/foo.sock',
+        10
+      )
+      metric.stats.should == {
+        :socket_active => 10,
+        :socket_queued => 7,
+        :socket_utilization => 70,
+      }
+    end
+  end
 end


### PR DESCRIPTION
Metrics are reported from health checks in the [OpenMetrics (aka Prometheus metrics)](https://gianarb.it/blog/prometheus-openmetrics-expositon-format) format. This will enable us to use open-source tooling that already speaks the OpenMetrics format to collect stats exposed by litmus_paper.