### PR TITLE
Rescue Metric::HaproxyBackendsHealth current_health when haproxy isn't running

### DIFF
--- a/lib/litmus_paper/metric/haproxy_backends_health.rb
+++ b/lib/litmus_paper/metric/haproxy_backends_health.rb
@@ -23,6 +23,13 @@ module LitmusPaper
           .inject(0) { |sum, server| sum + server["weight"].to_f }
 
         ((up_weight / total_weight) * @weight).to_i
+
+      rescue Timeout::Error
+        LitmusPaper.logger.info("HAProxy available check timed out for #{@cluster}")
+        0
+      rescue => e
+        LitmusPaper.logger.info("HAProxy available check failed for #{@cluster} with #{e.message}")
+        0
       end
 
       def stats

--- a/spec/litmus_paper/app_spec.rb
+++ b/spec/litmus_paper/app_spec.rb
@@ -60,6 +60,16 @@ describe LitmusPaper::App do
       last_response.body.should include('Forcing health')
       last_response.body.should include('88')
     end
+
+    it "returns successfully if a haproxy backend socket is unreachable" do
+      LitmusPaper.services['test'] = LitmusPaper::Service.new('test', [], [LitmusPaper::Metric::HaproxyBackendsHealth.new(100, "/tmp/non-existant-socketfile", "haproxy")])
+
+      get "/"
+
+      last_response.status.should == 200
+      last_response.body.should include('test')
+      last_response.body.should include('0')
+    end
   end
 
   describe "POST /up" do

--- a/spec/litmus_paper/metric/haproxy_backends_health_spec.rb
+++ b/spec/litmus_paper/metric/haproxy_backends_health_spec.rb
@@ -28,6 +28,11 @@ describe LitmusPaper::Metric::HaproxyBackendsHealth do
       health = LitmusPaper::Metric::HaproxyBackendsHealth.new(50, "/tmp/stub-haproxy-stats", "yellow_cluster")
       health.current_health.should == 16
     end
+
+    it "should return a health of 0 if haproxy is not running" do
+      health = LitmusPaper::Metric::HaproxyBackendsHealth.new(100, "/tmp/non-existant-socketfile", "red_cluster")
+      health.current_health.should == 0
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
Otherwise this raises an uncaught exception and causes litmus to return a 500.

(Closes: #45)