### PR TITLE
Add missing return for super call in Metric.const_missing

### DIFF
--- a/lib/litmus_paper/metric/unix_socket_utilization.rb
+++ b/lib/litmus_paper/metric/unix_socket_utilization.rb
@@ -25,7 +25,7 @@ module LitmusPaper
     end
 
     def self.const_missing(const_name)
-      super unless const_name == :UnixSocketUtilitization
+      return super unless const_name == :UnixSocketUtilitization
       warn "`LitmusPaper::Metric::UnixSocketUtilitization` has been deprecated. Use `LitmusPaper::Metric::UnixSocketUtilization` instead."
       UnixSocketUtilization
     end


### PR DESCRIPTION
In #46, I introduced a deprecated alias for the typo'd constant `UnixSocketUtilitization` using `const_missing`. Unfortunately, I left out the `return` on the `super` call. This doesn't cause any problems as-is, but would do confusing, unexpected things if someone were to reference a constant that doesn't exist within `Metric`, e.g. while developing a new metric.