### PR TITLE
Implement single-port mode for agent check server

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,15 +203,18 @@ There are no additional configuration files for the agent check, since all optio
 
 ```
 Usage: litmus-agent-check [options]
-    -s, --service SERVICE:PORT,...   agent-check service to port mappings
+    -s, --service SERVICE:PORT,...   agent-check service to port mappings (multi-port mode)
     -c, --config CONFIG              Path to litmus paper config file
     -p, --pid-file PID_FILE          Where to write the pid
+    -P, --port PORT                  Port for agent check. Can be used with HAProxy 1.7+ with agent-send directive (single-port mode)
     -w, --workers WORKERS            Number of worker processes
     -D, --daemonize                  Daemonize the process
     -h, --help                       Help text
 ```
 
-The service:port argument means that the server will expose the data from the litmus check for `service` on `port` in HAProxy agent check format. For example, if you wanted to serve status information about `myapp` on port `8080`, and already had a service config for it, you'd pass `-s myapp:8080`.
+In single-port mode, the `-P` or `--port` argument specifies the port that the server will expose the data for all services litmus is configured for on `port` in HAProxy agent check format. This can be used on HAProxy 1.7+ with the `agent-send` directive to specify a backend name to be sent by HAProxy and have litmus paper do the lookup. For example, `agent-send "my_service\n"`.
+
+In multi-port mode, the service:port argument means that the server will expose the data from the litmus check for `service` on `port` in HAProxy agent check format. For example, if you wanted to serve status information about `myapp` on port `8080`, and already had a service config for it, you'd pass `-s myapp:8080`.
 
 On the HAProxy server, add `agent-check agent-port 8080 agent-inter <seconds>s` to the config line for each server listed for that backend. This tells HAProxy to query port 8080 on the backend every `<seconds>` seconds for health information. See the [HAProxy agent check documentation](https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-agent-check) for more details.
 

--- a/lib/litmus_paper/agent_check_handler.rb
+++ b/lib/litmus_paper/agent_check_handler.rb
@@ -8,6 +8,10 @@ module LitmusPaper
       )
       output = []
 
+      if !service
+        return "failed#BAD_INPUT"
+      end
+
       health = @cache.get(service)
       if !health
         @cache.set(

--- a/lib/litmus_paper/agent_check_server.rb
+++ b/lib/litmus_paper/agent_check_server.rb
@@ -25,7 +25,7 @@ module LitmusPaper
     end
 
 
-    def service_for_socket(sock, addr)
+    def service_for_socket(socket)
       raise "Consumers must implemented service_for_socket(socket)"
     end
 

--- a/lib/litmus_paper/agent_check_server.rb
+++ b/lib/litmus_paper/agent_check_server.rb
@@ -8,7 +8,7 @@ module LitmusPaper
   module AgentCheckServer
     CRLF = "\r\n".freeze
 
-    attr_reader :control_sockets, :pid_file, :services, :workers
+    attr_reader :control_sockets, :pid_file, :workers
 
     def initialize(litmus_paper_config, daemonize, pid_file, workers)
       LitmusPaper.configure(litmus_paper_config)

--- a/lib/litmus_paper/cli/agent_check.rb
+++ b/lib/litmus_paper/cli/agent_check.rb
@@ -1,5 +1,6 @@
 require 'optparse'
-require 'litmus_paper/agent_check_server'
+require 'litmus_paper/single_port_agent_server'
+require 'litmus_paper/multi_port_agent_server'
 
 module LitmusPaper
   module CLI
@@ -9,7 +10,7 @@ module LitmusPaper
         options = {}
         options[:pid_file] = '/tmp/litmus-agent-check.pid'
         optparser = OptionParser.new do |opts|
-          opts.on("-s", "--service SERVICE:PORT,...", Array, "agent-check service to port mappings") do |s|
+          opts.on("-s", "--service SERVICE:PORT,...", Array, "agent-check service to port mappings (multi-port mode)") do |s|
             options[:services] = s
           end
           opts.on("-c", "--config CONFIG", "Path to litmus paper config file") do |c|
@@ -17,6 +18,9 @@ module LitmusPaper
           end
           opts.on("-p", "--pid-file PID_FILE", String, "Where to write the pid") do |p|
             options[:pid_file] = p
+          end
+          opts.on("-P", "--port PORT", Integer, "Port for agent check. Can be used with HAProxy 1.7+ with agent-send directive (single-port mode)") do |port|
+            options[:port] = port
           end
           opts.on("-w", "--workers WORKERS", Integer, "Number of worker processes") do |w|
             options[:workers] = w
@@ -42,8 +46,12 @@ module LitmusPaper
           exit 0
         end
 
-        if !options.has_key?(:services)
-          puts "Error: `-s SERVICE:PORT,...` required"
+        if !options.has_key?(:services) && !options.has_key?(:port)
+          puts "Error: `-s SERVICE:PORT,...` or `-P PORT` required"
+          puts optparser
+          exit 1
+        elsif options.has_key?(:services) && options.has_key?(:port)
+          puts "Error: `-s` and `-P` are mutually exclusive and cannot be specified together"
           puts optparser
           exit 1
         end
@@ -56,15 +64,17 @@ module LitmusPaper
           exit 1
         end
 
-        options[:services] = options[:services].reduce({}) do |memo, service|
-          if service.split(':').length == 2
-            service, port = service.split(':')
-            memo[port.to_i] = service
-            memo
-          else
-            puts "Error: Incorrect service port arg `-s SERVICE:PORT,...`"
-            puts optparser
-            exit 1
+        if options.has_key?(:services)
+          options[:services] = options[:services].reduce({}) do |memo, service|
+            if service.split(':').length == 2
+              service, port = service.split(':')
+              memo[port.to_i] = service
+              memo
+            else
+              puts "Error: Incorrect service port arg `-s SERVICE:PORT,...`"
+              puts optparser
+              exit 1
+            end
           end
         end
 
@@ -73,13 +83,25 @@ module LitmusPaper
 
       def run(args)
         options = parse_args(args)
-        agent_check_server = LitmusPaper::AgentCheckServer.new(
-          options[:litmus_paper_config],
-          options[:services],
-          options[:workers],
-          options[:pid_file],
-          options[:daemonize],
-        )
+
+        if options.has_key?(:port)
+          agent_check_server = LitmusPaper::SinglePortAgentServer.new(
+            options[:litmus_paper_config],
+            options[:daemonize],
+            options[:pid_file],
+            options[:port],
+            options[:workers],
+          )
+        else
+          agent_check_server = LitmusPaper::MultiPortAgentServer.new(
+            options[:litmus_paper_config],
+            options[:daemonize],
+            options[:pid_file],
+            options[:services],
+            options[:workers],
+          )
+        end
+
         agent_check_server.run
       end
 

--- a/lib/litmus_paper/metric/tcp_socket_utilization.rb
+++ b/lib/litmus_paper/metric/tcp_socket_utilization.rb
@@ -20,7 +20,7 @@ module LitmusPaper
         queued = current_stats[:socket_queued]
         utilization = current_stats[:socket_utilization]
 
-        "Metric::TcpSocketUtilitization(weight: #{weight}, maxconn: #{maxconn}, active: #{active}, queued: #{queued}, utilization: #{utilization}, address: #{address})"
+        "Metric::TcpSocketUtilization(weight: #{weight}, maxconn: #{maxconn}, active: #{active}, queued: #{queued}, utilization: #{utilization}, address: #{address})"
       end
     end
   end

--- a/lib/litmus_paper/multi_port_agent_server.rb
+++ b/lib/litmus_paper/multi_port_agent_server.rb
@@ -12,10 +12,10 @@ module LitmusPaper
       end
     end
 
-    def service_for_connection(sock, addr)
-      _, remote_port, _, remote_ip = sock.peeraddr
+    def service_for_socket(socket)
+      _, remote_port, _, remote_ip = socket.peeraddr
       LitmusPaper.logger.debug "Received request from #{remote_ip}:#{remote_port}"
-      services[sock.local_address.ip_port]
+      services[socket.local_address.ip_port]
     end
   end
 end

--- a/lib/litmus_paper/multi_port_agent_server.rb
+++ b/lib/litmus_paper/multi_port_agent_server.rb
@@ -4,6 +4,8 @@ module LitmusPaper
   class MultiPortAgentServer
     include AgentCheckServer
 
+    attr_reader :services
+
     def initialize(litmus_paper_config, daemonize, pid_file, services, workers)
       super(litmus_paper_config, daemonize, pid_file, workers)
       @services = services

--- a/lib/litmus_paper/multi_port_agent_server.rb
+++ b/lib/litmus_paper/multi_port_agent_server.rb
@@ -13,7 +13,7 @@ module LitmusPaper
     end
 
     def service_for_socket(socket)
-      _, remote_port, _, remote_ip = socket.peeraddr
+      _, remote_port, _, remote_ip = socket.peeraddr(:numeric)
       LitmusPaper.logger.debug "Received request from #{remote_ip}:#{remote_port}"
       services[socket.local_address.ip_port]
     end

--- a/lib/litmus_paper/multi_port_agent_server.rb
+++ b/lib/litmus_paper/multi_port_agent_server.rb
@@ -1,0 +1,21 @@
+require 'litmus_paper/agent_check_server'
+
+module LitmusPaper
+  class MultiPortAgentServer
+    include AgentCheckServer
+
+    def initialize(litmus_paper_config, daemonize, pid_file, services, workers)
+      super(litmus_paper_config, daemonize, pid_file, workers)
+      @services = services
+      @control_sockets = @services.keys.map do |port|
+        TCPServer.new(port)
+      end
+    end
+
+    def service_for_connection(sock, addr)
+      _, remote_port, _, remote_ip = sock.peeraddr
+      LitmusPaper.logger.debug "Received request from #{remote_ip}:#{remote_port}"
+      services[sock.local_address.ip_port]
+    end
+  end
+end

--- a/lib/litmus_paper/single_port_agent_server.rb
+++ b/lib/litmus_paper/single_port_agent_server.rb
@@ -1,0 +1,31 @@
+require 'litmus_paper/agent_check_server'
+
+module LitmusPaper
+  class SinglePortAgentServer
+    include AgentCheckServer
+
+    VALID_NAME_REGEX = /\A([A-Za-z0-9_:.-]+)\z/.freeze
+    MAX_BACKEND_NAME_LEN = 255.freeze
+
+    def initialize(litmus_paper_config, daemonize, pid_file, port, workers)
+      super(litmus_paper_config, daemonize, pid_file, workers)
+      @services = LitmusPaper.services
+      @control_sockets = [TCPServer.new(port)]
+    end
+
+    def service_for_connection(sock, addr)
+      _, remote_port, _, remote_ip = sock.peeraddr
+
+      msg = sock.gets.chomp
+
+      if m = msg.match(VALID_NAME_REGEX)
+        backend_name = m[0]
+        LitmusPaper.logger.debug "Received request from #{remote_ip}:#{remote_port} for '#{backend_name}'"
+        backend_name
+      else
+        LitmusPaper.logger.error "Received request from #{remote_ip}:#{remote_port}, but backend name could not be read."
+        nil
+      end
+    end
+  end
+end

--- a/lib/litmus_paper/single_port_agent_server.rb
+++ b/lib/litmus_paper/single_port_agent_server.rb
@@ -4,8 +4,7 @@ module LitmusPaper
   class SinglePortAgentServer
     include AgentCheckServer
 
-    VALID_NAME_REGEX = /\A([A-Za-z0-9_:.-]+)\z/.freeze
-    MAX_BACKEND_NAME_LEN = 255.freeze
+    VALID_NAME_REGEX = /\A[A-Za-z0-9_:.-]+\z/.freeze
 
     def initialize(litmus_paper_config, daemonize, pid_file, port, workers)
       super(litmus_paper_config, daemonize, pid_file, workers)
@@ -13,14 +12,14 @@ module LitmusPaper
       @control_sockets = [TCPServer.new(port)]
     end
 
-    def service_for_connection(sock, addr)
-      _, remote_port, _, remote_ip = sock.peeraddr
+    def service_for_socket(socket)
+      _, remote_port, _, remote_ip = socket.peeraddr
 
-      msg = sock.gets.chomp
+      msg = socket.gets
 
-      if m = msg.match(VALID_NAME_REGEX)
+      if msg && (m = msg.chomp.match(VALID_NAME_REGEX))
         backend_name = m[0]
-        LitmusPaper.logger.debug "Received request from #{remote_ip}:#{remote_port} for '#{backend_name}'"
+        LitmusPaper.logger.info "Received request from #{remote_ip}:#{remote_port} for '#{backend_name}'"
         backend_name
       else
         LitmusPaper.logger.error "Received request from #{remote_ip}:#{remote_port}, but backend name could not be read."

--- a/lib/litmus_paper/single_port_agent_server.rb
+++ b/lib/litmus_paper/single_port_agent_server.rb
@@ -8,7 +8,6 @@ module LitmusPaper
 
     def initialize(litmus_paper_config, daemonize, pid_file, port, workers)
       super(litmus_paper_config, daemonize, pid_file, workers)
-      @services = LitmusPaper.services
       @control_sockets = [TCPServer.new(port)]
     end
 

--- a/lib/litmus_paper/single_port_agent_server.rb
+++ b/lib/litmus_paper/single_port_agent_server.rb
@@ -13,7 +13,7 @@ module LitmusPaper
     end
 
     def service_for_socket(socket)
-      _, remote_port, _, remote_ip = socket.peeraddr
+      _, remote_port, _, remote_ip = socket.peeraddr(:numeric)
 
       msg = socket.gets
 

--- a/spec/litmus_paper/multi_port_agent_server_spec.rb
+++ b/spec/litmus_paper/multi_port_agent_server_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'litmus_paper/multi_port_agent_server'
+
+describe LitmusPaper::MultiPortAgentServer do
+  pid = nil
+
+  before :all do
+    if ! Kernel.system("bundle exec litmus-agent-check -s passing_test:9191,test:9192 -c spec/support/test.config -w 10 -D")
+      fail('Unable to start server')
+    end
+    port_open = false
+    while ! port_open do
+      begin
+        TCPSocket.new('127.0.0.1', 9191)
+      rescue StandardError => e
+        sleep 0.1
+        next
+      end
+      port_open = true
+    end
+  end
+
+  after :all do
+    Process.kill(:TERM, File.read('/tmp/litmus-agent-check.pid').to_i)
+  end
+
+  describe "The agent-check text protocol" do
+    it "returns the health from a passing test" do
+      TCPSocket.open('127.0.0.1', 9191) do |s|
+        s.gets.should match(/ready\tup\t\d+%\r\n/)
+      end
+    end
+    it "returns the health from a failing test" do
+      TCPSocket.open('127.0.0.1', 9192) do |s|
+        s.gets.should match(/down\t0%\r\n/)
+      end
+    end
+  end
+
+  describe "server" do
+    it "has the configured number of children running" do
+      pid = File.read('/tmp/litmus-agent-check.pid').to_i
+      children = `ps --no-headers --ppid #{pid}|wc -l`
+      children.strip.to_i == 10
+    end
+  end
+
+  describe "server" do
+    it "if a child dies you get a new one" do
+      pid = File.read('/tmp/litmus-agent-check.pid').to_i
+      Kernel.system("kill -9 $(ps --no-headers --ppid #{pid} -o pid=|tail -1)")
+      sleep 0.5
+      children = `ps --no-headers --ppid #{pid}|wc -l`
+      children.strip.to_i == 10
+    end
+  end
+end

--- a/spec/litmus_paper/single_port_agent_server_spec.rb
+++ b/spec/litmus_paper/single_port_agent_server_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
-require 'litmus_paper/agent_check_server'
+require 'litmus_paper/single_port_agent_server'
 
-describe LitmusPaper::AgentCheckServer do
+describe LitmusPaper::SinglePortAgentServer do
   pid = nil
 
   before :all do
-    if ! Kernel.system("bundle exec litmus-agent-check -s passing_test:9191,test:9192 -c spec/support/test.config -w 10 -D")
+    if ! Kernel.system("bundle exec litmus-agent-check -P 9191 -c spec/support/test.config -w 10 -D")
       fail('Unable to start server')
     end
     port_open = false
@@ -27,12 +27,26 @@ describe LitmusPaper::AgentCheckServer do
   describe "The agent-check text protocol" do
     it "returns the health from a passing test" do
       TCPSocket.open('127.0.0.1', 9191) do |s|
+        s.puts "passing_test"
         s.gets.should match(/ready\tup\t\d+%\r\n/)
       end
     end
     it "returns the health from a failing test" do
-      TCPSocket.open('127.0.0.1', 9192) do |s|
+      TCPSocket.open('127.0.0.1', 9191) do |s|
+        s.puts "test"
         s.gets.should match(/down\t0%\r\n/)
+      end
+    end
+    it "returns a failure for a non-existent service" do
+      TCPSocket.open('127.0.0.1', 9191) do |s|
+        s.puts "foo"
+        s.gets.should match(/failed#NOT_FOUND\r\n/)
+      end
+    end
+    it "returns a failure for a bad message" do
+      TCPSocket.open('127.0.0.1', 9191) do |s|
+        s.puts "\n"
+        s.gets.should match(/failed#BAD_INPUT\r\n/)
       end
     end
   end


### PR DESCRIPTION
This PR introduces a single-port mode for Litmus Paper's agent check for use with HAProxy 1.7+ `agent-send` directive to lower the configuration burden on using Litmus Paper with many services.

Instead of specifying various port mappings via `-s`, you need only specify a single TCP port that will be opened at used to receive a single string from HAProxy of the service name (via `agent-send`), which will be used to return the status for that service.

We're still doing testing with this, but would like to open this for comment to see if it's a) a desired feature, and b) for any feedback about approach/implementation. 